### PR TITLE
修复当启动orthanc的账户管理功能时，图像页面因为请求中没有附带Authorization: 而一起不能加载

### DIFF
--- a/.docker/Nginx-Orthanc/config/orthanc.json
+++ b/.docker/Nginx-Orthanc/config/orthanc.json
@@ -30,9 +30,9 @@
   "RemoteAccessAllowed": true,
   "SslEnabled": false,
   "SslCertificate": "certificate.pem",
-  "AuthenticationEnabled": false,
+  "AuthenticationEnabled": true,
   "RegisteredUsers": {
-    "test": "test"
+    "orthanc": "3ddiZVEx3wQpjKb"
   },
   "DicomModalities": {},
   "DicomModalitiesInDatabase": false,

--- a/.docker/Nginx-Orthanc/docker-compose.yml
+++ b/.docker/Nginx-Orthanc/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   orthanc:
-    image: jodogne/orthanc-plugins:1.5.6
+    image: jodogne/orthanc-plugins:1.10.1
     hostname: orthanc
     volumes:
       # Config

--- a/platform/viewer/public/config/docker_nginx-orthanc.js
+++ b/platform/viewer/public/config/docker_nginx-orthanc.js
@@ -11,7 +11,11 @@ window.config = {
         qidoSupportsIncludeField: false,
         imageRendering: 'wadors',
         thumbnailRendering: 'wadors',
+        requestOptions: {
+          auth: 'orthanc:3ddiZVEx3wQpjKb',
+        },
       },
     ],
   },
+  studyListFunctionsEnabled: true,
 };

--- a/platform/viewer/src/config.js
+++ b/platform/viewer/src/config.js
@@ -41,10 +41,14 @@ export function setConfiguration(appConfig) {
 
     return appConfig.httpErrorHandler;
   };
-
+  const isActive = a => a.active === true;
   cornerstoneWADOImageLoader.configure({
     beforeSend: function(xhr) {
-      const headers = OHIF.DICOMWeb.getAuthorizationHeader();
+      // 因为设置requestOptions属性后，需要在请求中附带Authorization: Basic ?信息
+      const state = window.store.getState();
+      const activeServer = state.servers.servers.find(isActive);
+
+      const headers = OHIF.DICOMWeb.getAuthorizationHeader(activeServer);
 
       if (headers.Authorization) {
         xhr.setRequestHeader('Authorization', headers.Authorization);


### PR DESCRIPTION
### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
